### PR TITLE
Fix Chunky-V1 plugin not autoloading

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ install_requires =
 
 
 [options.entry_points]
-relic.sga.handler =
-    v1.1 = relic.sga.v1.serialization:chunky_fs_serializer
+relic.chunky.handler =
+    v1.1 = relic.chunky.v1.serialization:chunky_fs_serializer
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Setup.cfg was borked, this should fix MAK-Relic-Tool/Issue-Tracker#7